### PR TITLE
fix: remove https:// prefix from go install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Once installed, you can run `helm tui` directly from your terminal.
 ### Install using Go:
 
 ```bash
-go install https://github.com/pidanou/helm-tui@latest
+go install github.com/pidanou/helm-tui@latest
 ```
 
 Once installed, you can run `helm-tui` directly from your terminal.


### PR DESCRIPTION
README.md was using `https://` prefix with `go install`, that's not a valid command to use.

This change fix this by removing `https://`.